### PR TITLE
Integrate existing HANA schema

### DIFF
--- a/.cdsrc.json
+++ b/.cdsrc.json
@@ -1,0 +1,12 @@
+{
+  "cds": {
+    "requires": {
+      "db": {
+        "kind": "hana",
+        "credentials": {
+          "schema": "SAP_HANA_CORE"
+        }
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ File or Folder | Purpose
 ## Learn More
 
 Learn more at https://cap.cloud.sap/docs/get-started/.
+
+## Using Existing HANA Schema
+
+This project is configured to consume the existing HANA schema `SAP_HANA_CORE` and table `PLTFM_USR_ACC`. The CAP model `db/external.cds` marks the entity `UserAccounts` as an existing table and maps it to the fully qualified name `"SAP_HANA_CORE"."PLTFM_USR_ACC"`.
+
+The `.cdsrc.json` file sets the schema for the database connection. Ensure that the application has privileges to access this schema at runtime.

--- a/db/src/external.cds
+++ b/db/src/external.cds
@@ -1,0 +1,9 @@
+namespace db;
+
+@cds.persistence.exists
+@cds.persistence.name: '"SAP_HANA_CORE"."PLTFM_USR_ACC"'
+entity UserAccounts {
+  key USER_ID   : String(50);
+  USER_NAME     : String(100);
+  EMAIL         : String(100);
+}

--- a/db/src/pltfm_usr_acc.hdbsynonym
+++ b/db/src/pltfm_usr_acc.hdbsynonym
@@ -1,0 +1,8 @@
+{
+  "PLTFM_USR_ACC": {
+    "target": {
+      "schema": "SAP_HANA_CORE",
+      "object": "PLTFM_USR_ACC"
+    }
+  }
+}

--- a/srv/user-service.cds
+++ b/srv/user-service.cds
@@ -1,0 +1,5 @@
+using { db } from '../db';
+
+service UserService {
+  entity UserAccounts as projection on db.UserAccounts;
+}


### PR DESCRIPTION
## Summary
- map to existing schema `SAP_HANA_CORE` in cds config
- add cds model for existing table `PLTFM_USR_ACC`
- create synonym to reference the table
- expose the table via `UserService`
- document how to use the existing schema

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a5a37b074832d83fcea1022d9bb87